### PR TITLE
Removed network from HotAccount in KeyPair

### DIFF
--- a/Sources/Kinetic/Models/Keypair.swift
+++ b/Sources/Kinetic/Models/Keypair.swift
@@ -71,7 +71,7 @@ public struct Keypair: Codable, Hashable {
 
     public static func derive(seed: [UInt8], walletIndex: Int) throws -> Keypair {
         let mnemonic = Mnemonic(entropy: seed)!
-        let solanaKeypair = HotAccount(phrase: mnemonic.phrase, network: .devnet, derivablePath: DerivablePath(type: .bip44Change, walletIndex: walletIndex))!
+        let solanaKeypair = HotAccount(phrase: mnemonic.phrase, derivablePath: DerivablePath(type: .bip44Change, walletIndex: walletIndex))!
         var kp = try Keypair(secretKey: Base58.encode(solanaKeypair.secretKey.bytes))
         kp.mnemonic = mnemonic.phrase
         return kp


### PR DESCRIPTION
I think it's possible Kinetic's Solana dependency has changed recently and no longer requires the `network` parameter in `HotAccount`. 

I was receiving the following error when trying to build:

<img width="350" alt="Screenshot 2022-11-17 at 22 25 14" src="https://user-images.githubusercontent.com/1658558/202574330-80f86bb8-8a84-40c8-8c4b-01b36fe18ce9.png">
